### PR TITLE
chore: typo `provider` -> `currency`

### DIFF
--- a/src/book_manager.cairo
+++ b/src/book_manager.cairo
@@ -152,8 +152,8 @@ pub mod BookManager {
             self.default_provider.read()
         }
 
-        fn reserves_of(self: @ContractState, provider: ContractAddress) -> u256 {
-            self.reserves_of.read(provider)
+        fn reserves_of(self: @ContractState, currency: ContractAddress) -> u256 {
+            self.reserves_of.read(currency)
         }
 
         fn is_whitelisted(self: @ContractState, provider: ContractAddress) -> bool {

--- a/src/interfaces/book_manager.cairo
+++ b/src/interfaces/book_manager.cairo
@@ -127,7 +127,7 @@ pub trait IBookManager<TContractState> {
     fn base_uri(self: @TContractState) -> ByteArray;
     fn contract_uri(self: @TContractState) -> ByteArray;
     fn default_provider(self: @TContractState) -> ContractAddress;
-    fn reserves_of(self: @TContractState, provider: ContractAddress) -> u256;
+    fn reserves_of(self: @TContractState, currency: ContractAddress) -> u256;
     fn is_whitelisted(self: @TContractState, provider: ContractAddress) -> bool;
     fn check_authorized(
         self: @TContractState, owner: ContractAddress, spender: ContractAddress, token_id: felt252


### PR DESCRIPTION
Fix #18.